### PR TITLE
fix: ellipses displaying even when the text does not exceed the limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const text = {
 | top            | number \| () => number        | -                  | （必填）相对父元素y轴的偏移                          |
 | width          | number                        | -                  | 文本宽度                                             |
 | content        | string                        | -                  | 文本内容                                             |
+| color          | string                        | -                  | 字体颜色                                             |
 | fontSize       | number                        | 14                 | 字体大小                                             |
 | fontWeight     | string                        | 'normal'           | 字体的粗细程度，一些字体只提供 normal 和 bold 两种值 |
 | fontFamily     | string                        | 'sans-serif'       | 字体名称                                             |

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,10 @@ export class MiniPoster {
         }
       }
 
+      if (index === mid) {
+        mid = index + 1;
+      }
+
       if (lineClamp === lines.length + 1 && mid < length) {
         lines.push(content.slice(index, mid - 1) + '...');
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
 import { isNonEmptyArray } from '@inottn/fp-utils';
 import { loadFontFace, toTempFilePath } from './adapter';
-import {
-  binarySearch,
-  calculateLeftOffset,
-  mergePosition,
-  normalizeConfig,
-} from './utils';
+import { calculateLeftOffset, mergePosition, normalizeConfig } from './utils';
 import type {
   AugmentedRequired,
   Canvas,
@@ -224,28 +219,45 @@ export class MiniPoster {
   getAllLines(data: TextConfig) {
     const { context } = this;
     const { width, content, lineClamp = Infinity } = data;
+
+    if (width == void 0) {
+      return [content];
+    }
+
+    if (width <= 0) {
+      return content.split('');
+    }
+
     const lines = [];
     let index = 0;
+    const { length } = content;
 
-    while (index < content.length && lines.length < lineClamp) {
-      const prevIndex = index;
-
-      index =
-        binarySearch(
-          content,
-          (end) =>
-            context.measureText(content.slice(index, end + 1)).width > width!,
-        ) + 1;
-
-      if (index === prevIndex) {
-        index = prevIndex + 1;
+    while (index < length && lines.length < lineClamp) {
+      let left = index;
+      let right = length;
+      let mid = right;
+      while (left < mid) {
+        const measureWidth = context.measureText(
+          content.slice(index, mid),
+        ).width;
+        if (measureWidth > width) {
+          right = mid;
+          mid = left + ((mid - left) >> 1);
+        } else if (measureWidth < width) {
+          left = mid;
+          mid = mid + ((right - mid) >> 1);
+        } else {
+          break;
+        }
       }
 
-      if (lineClamp === lines.length + 1) {
-        lines.push(content.slice(prevIndex, index - 1) + '...');
+      if (lineClamp === lines.length + 1 && mid < length) {
+        lines.push(content.slice(index, mid - 1) + '...');
       } else {
-        lines.push(content.slice(prevIndex, index));
+        lines.push(content.slice(index, mid));
       }
+
+      index = mid;
     }
 
     return lines;


### PR DESCRIPTION
1. 优化了二分法测量文本宽度的算法，减少了一些不需要的测量
2. 对width参数加了校验
3. 修复了 lineClamp 的省略号在文本未超出时也显示的问题